### PR TITLE
fix: #65 회원가입 후 토큰 및 쿠키 관리 오류 수정

### DIFF
--- a/src/app/sign-in/kakao/page.tsx
+++ b/src/app/sign-in/kakao/page.tsx
@@ -1,16 +1,17 @@
 'use client';
 
+import CALLBACK_URL from '@/constants/url';
+import useUserStore from '@/store/user/userStore';
+import getUserInfo from '@/app/api/auth/getUserInfo';
+
 import { useEffect } from 'react';
 import { setCookie } from '@/lib/cookie';
 import { encrypt } from '@/utils/crypto';
 import { useRouter } from 'next/navigation';
 import { getEmail } from '@/utils/getEmail';
 import { useToast } from '@/app/_components/ui/use-toast';
+import { setTokensInCookies } from '@/utils/setTokensInCookies';
 import { ERROR_CODE, STATUS_CODE } from '@/constants/api/statusCode';
-
-import CALLBACK_URL from '@/constants/url';
-import getUserInfo from '@/app/api/auth/getUserInfo';
-import useUserStore from '@/store/user/userStore';
 
 // 카카오 소셜 로그인 REDIRECT URI PAGE
 function Page() {
@@ -27,15 +28,9 @@ function Page() {
       const response = await getUserInfo({ code, signUpType });
 
       if (response && response.data && response.data.refresh_token) {
-        setCookie({
-          name: 'access_token',
-          value: encrypt(response.data.access_token),
-          options: { path: '/' },
-        });
-        setCookie({
-          name: 'refresh_token',
-          value: encrypt(response.data.refresh_token),
-          options: { path: '/' },
+        setTokensInCookies({
+          accessToken: response.data.access_token,
+          refreshToken: response.data.refresh_token,
         });
       }
 

--- a/src/app/sign-up/_components/SignUpForm.tsx
+++ b/src/app/sign-up/_components/SignUpForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { setTokensInCookies } from '@/utils/setTokensInCookies';
 import { FormSchemaType, formSchema } from '@/app/sign-up/schema';
-import { useRouter } from 'next/navigation';
 import {
   BIRTHDAY_INPUT,
   GENDER_INPUT,
@@ -43,12 +44,19 @@ function SignUpForm() {
   };
 
   const onSubmit: SubmitHandler<FormSchemaType> = async formData => {
-    await postSignUp({
+    const response = await postSignUp({
       ...formData,
       sign_up_type: signUpType,
       email,
       profile_image,
     });
+
+    if (response && response.data) {
+      setTokensInCookies({
+        accessToken: response.data.access_token,
+        refreshToken: response.data.refresh_token,
+      });
+    }
 
     router.push(CALLBACK_URL.service);
   };

--- a/src/app/sign-up/api/postSignUp.ts
+++ b/src/app/sign-up/api/postSignUp.ts
@@ -2,12 +2,18 @@ import CustomError from '@/error/CustomError';
 import { axiosInstance } from '@/lib/axios/axios-instance';
 import { END_POINT } from '@/constants/api/end-point';
 import { PostSignUpProps } from '@/types/sign-up';
+import { TResponse } from '@/types/common/response';
+import { UserInfoProps } from '@/types/sign-in';
 
 const postSignUp = async ({ ...data }: PostSignUpProps) => {
   try {
-    await axiosInstance.post(END_POINT.auth.signUp, {
+    const { data: response } = await axiosInstance.post<
+      TResponse<UserInfoProps>
+    >(END_POINT.auth.signUp, {
       ...data,
     });
+
+    return response;
   } catch (error: unknown) {
     if (error instanceof CustomError) {
       throw new Error(error.message);

--- a/src/types/my-page/index.ts
+++ b/src/types/my-page/index.ts
@@ -2,3 +2,12 @@ export interface EditProfileProps {
   id: number;
   nickname: string;
 }
+
+export interface UserProps {
+  email: string;
+  nickname: string;
+  birthday: string;
+  profile_image: string;
+  sign_up_type: number;
+  gender: number;
+}

--- a/src/types/sign-up/index.ts
+++ b/src/types/sign-up/index.ts
@@ -13,3 +13,8 @@ export interface PostSignUpProps {
   birthday: string;
   profile_image: string;
 }
+
+export interface SetTokensInCookiesProps {
+  accessToken: string;
+  refreshToken: string;
+}

--- a/src/utils/setTokensInCookies.ts
+++ b/src/utils/setTokensInCookies.ts
@@ -1,0 +1,27 @@
+import { setCookie } from '@/lib/cookie';
+import { encrypt } from '@/utils/crypto';
+import { SetTokensInCookiesProps } from '@/types/sign-up';
+
+/**
+ * 암호화된 access_token과 refresh_token을 쿠키에 설정합니다.
+ *
+ * @param {string} accessToken - 'access_token' 쿠키에 저장될 액세스 토큰
+ * @param {string} refreshToken - 'refresh_token' 쿠키에 저장될 리프레시 토큰
+ *
+ * @returns {void}
+ */
+export const setTokensInCookies = ({
+  accessToken,
+  refreshToken,
+}: SetTokensInCookiesProps) => {
+  setCookie({
+    name: 'access_token',
+    value: encrypt(accessToken),
+    options: { path: '/' },
+  });
+  setCookie({
+    name: 'refresh_token',
+    value: encrypt(refreshToken),
+    options: { path: '/' },
+  });
+};


### PR DESCRIPTION
## 개요
비회원은 회원가입 이후 유효한 액세스 토큰과 리프레시 토큰을 쿠키에 저장합니다.

기존에 저장하지 못했던 오류를 수정하여  회원가입 이후 원활한 API 통신 테스트 완료했습니다.

Resolves: #65

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
