### PR TITLE
Fix: #56 review UI, 버그 수정

### DIFF
--- a/src/app/_components/modal/ImageModal.tsx
+++ b/src/app/_components/modal/ImageModal.tsx
@@ -4,8 +4,11 @@ import { COLOR } from '@/styles/color';
 import { useImageStore } from '@/store/modal/imageModalStore';
 
 function ImageModal() {
-  const width = window.outerWidth;
+  let width = 0;
 
+  if (typeof window !== 'undefined') {
+    width = window.outerWidth;
+  }
   const { image, isOpen, setModalClose } = useImageStore(state => state);
 
   if (!isOpen || typeof image !== 'string') return;

--- a/src/app/_components/review/review-modal/ReviewModal.tsx
+++ b/src/app/_components/review/review-modal/ReviewModal.tsx
@@ -70,7 +70,7 @@ function ReviewModal({ openPosition }: ReviewProps) {
         gym_name={reviews[0].data.data.gym_name}
       />
       <div className={ModalClassName}>
-        <div className="w-full max-w-[768px] z-[101] px-1 h-[3.5rem] fixed shadow flex items-center justify-center">
+        <div className="w-full max-w-[768px] z-[101] h-[3.5rem] fixed shadow flex items-center justify-center">
           <button type="button" className={PositionClassName} onClick={reset}>
             {openPosition === 'center' ? <ChevronDown /> : <ChevronLeft />}
           </button>

--- a/src/app/_components/review/review-modal/ReviewModalContainer.tsx
+++ b/src/app/_components/review/review-modal/ReviewModalContainer.tsx
@@ -1,6 +1,5 @@
 import { ReviewModalContainerProps } from '@/types/review/ReviewProps';
 import useReviewStore from '@/store/review/reviewStore';
-import { useEffect } from 'react';
 import ReviewModal from './ReviewModal';
 import MyReviewModal from './MyReviewModal';
 import ReviewModalSkeleton from './ReviwModalSkeleton';
@@ -9,9 +8,7 @@ function ReviewModalContainer({
   isMyPage,
   openPosition,
 }: ReviewModalContainerProps) {
-  const { reviewId, state } = useReviewStore(state => state);
-
-  useEffect(() => {}, [reviewId, state]);
+  const { reviewId } = useReviewStore(state => state);
 
   if (!isMyPage && reviewId === null) {
     return <ReviewModalSkeleton openPosition={openPosition} />;

--- a/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
+++ b/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
@@ -84,15 +84,15 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
     }
     closeMode();
   };
-
   return (
     <div className={ModalClassName}>
       <div className=" h-[3.5rem] shadow flex items-center justify-center">
         <button type="button" className="absolute right-3" onClick={closeMode}>
           <X />
         </button>
-        {state === 'create' ?? <span>리뷰작성</span>}
-        {state === 'fix' ?? <span>리뷰 수정</span>}
+        <span>
+          {state === 'create' ? '리뷰작성' : state === 'fix' ?? '리뷰 수정'}
+        </span>
       </div>
       <div
         className={`mx-4 pt-4 text-[20px] border-b border-primary ${aBeeZee.className}`}

--- a/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
+++ b/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
@@ -39,7 +39,7 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
   const isOpen = state === 'create' || state === 'fix';
 
   const ModalClassName = cn(
-    'w-full px-1 max-w-[768px] bg-white overflow-y-scroll duration-1000 h-full top-0 right-0 absolute bg-white',
+    'w-full max-w-[768px] bg-white overflow-y-scroll duration-1000 h-full top-0 right-0 absolute bg-white',
     { 'opacity-0 z-0': !isOpen },
     { 'opacity-1 z-[1000]': isOpen },
   );

--- a/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
+++ b/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
@@ -84,15 +84,23 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
     }
     closeMode();
   };
+
+  let header = null;
+  let submit = null;
+  if (state === 'create') {
+    header = '리뷰 작성';
+    submit = '작성 완료';
+  } else if (state === 'fix') {
+    header = '리뷰 수정';
+    submit = '수정 완료';
+  }
   return (
     <div className={ModalClassName}>
       <div className=" h-[3.5rem] shadow flex items-center justify-center">
         <button type="button" className="absolute right-3" onClick={closeMode}>
           <X />
         </button>
-        <span>
-          {state === 'create' ? '리뷰작성' : state === 'fix' ?? '리뷰 수정'}
-        </span>
+        {header}
       </div>
       <div
         className={`mx-4 pt-4 text-[20px] border-b border-primary ${aBeeZee.className}`}
@@ -145,7 +153,7 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
           <div className="flex flex-col items-end w-full gap-2 pb-4 z-50 bg-white">
             <PhotoBooth images={images} setImages={setImages} />
             <Button type="submit" color="white" className="w-full">
-              작성 완료
+              {submit}
             </Button>
           </div>
         </form>

--- a/src/app/service/map/_components/bottom-sheet/BottomSheetInner.tsx
+++ b/src/app/service/map/_components/bottom-sheet/BottomSheetInner.tsx
@@ -99,12 +99,14 @@ function BottomSheetInner({ data }: BottomSheetInnerProps) {
         <OneSiteUrl label="homepage" url={homepage_link} />
         <OneSiteUrl label="instagram" url={instagram_link} />
         <OneSiteUrl label="kakaomap" url={kakao_map_link} />
-        <div className="flex gap-2">
-          <Smartphone stroke={COLOR.primary} size={20} strokeWidth={1.25} />
-          <a className="cursor-pointer" href={`tel:${phone_number}`}>
-            {phone_number}
-          </a>
-        </div>
+        {phone_number ? (
+          <div className="flex gap-2">
+            <Smartphone stroke={COLOR.primary} size={20} strokeWidth={1.25} />
+            <a className="cursor-pointer" href={`tel:${phone_number}`}>
+              {phone_number}
+            </a>
+          </div>
+        ) : null}
       </div>
       <div className="shadow-custom-line h-[1px] py-1" />
       <div className="flex justify-between p-[0.75rem]">


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #(Isuue Number)

## PR 유형
어떤 변경 사항이 있나요?

1. 리뷰에서 자연스럽지 못한 UI를 수정하였습니다.
- 리뷰 수정모달에서 상태에 따른 Text가 다르게 보이게 수정하였습니다.
- padding 값을 제거하였습니다.
![image](https://github.com/Kernel360/f1-Orury-Client/assets/115636461/74299758-4517-424f-95d8-89d9a0ce8410)

2. map에서 번호가 없을 경우에도 아이콘을 노출되던 버그를 수정하였습니다.

다음 버그들이 있는 것 같습니다.

1. 본인이 작성한 리뷰 이외에도 본인의 리뷰 값이라고 요청이 되는 버그
2. 마이페이지에서는 수정이 불가능한 버그

2번의 버그같은 경우 현재 마이페이지를 kled님께서 직접 구현을 하셨기에 여기다가 구현 방법을 남겨두고 갑니다.

```typescript
<ReviewRegisterModal
        mutate={mutate}
        gym_name={reviews[0].data.data.gym_name}
      />
```

modal을 `ReviewModal.tsx` 파일을 참고하여 등록을 하여줍니다. `gym_name`의 경우 현재 수정중인 review의 gym name을 남기고 있어야 하기 때문에 state 값을 누를때마다 값이 변하게 하여 수정 버튼을 누른 gym의 name이 들어가게 해줍니다.

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
