### PR TITLE
Feat/#90 (내 리뷰 목록 조회 api 응답에 맞는) review.ts interface 생성

### DIFF
--- a/src/apis/review/hooks/useReview.ts
+++ b/src/apis/review/hooks/useReview.ts
@@ -1,5 +1,5 @@
 import useSWRInfinite from 'swr/infinite';
-import { ReviewResponseType } from '@/types/review/review';
+import {MyReviewResponseType, ReviewResponseType} from '@/types/review/review';
 import { getMyReviewKey, getReviewKey } from '@/apis/review/getKeys';
 import { axiosInstance } from '@/lib/axios/axios-instance';
 import { AxiosResponse } from 'axios';
@@ -7,7 +7,7 @@ import { TResponse } from '@/types/common/response';
 
 const useReviewApi = {
   useGetMyReviews: (cursor?: number) =>
-    useSWRInfinite<AxiosResponse<TResponse<ReviewResponseType>>[]>(
+    useSWRInfinite<AxiosResponse<TResponse<MyReviewResponseType>>[]>(
       (pageIndex, previousPageData) =>
         getMyReviewKey(pageIndex, previousPageData, cursor),
       axiosInstance.get,

--- a/src/app/_components/review/review-modal/MyReviewModal.tsx
+++ b/src/app/_components/review/review-modal/MyReviewModal.tsx
@@ -71,7 +71,7 @@ function MyReviewModal({ openPosition }: ReviewProps) {
         <div className="relative mt-[3.5rem]">
           {reviews[0].data.data.cursor !== -2 ? (
             reviews
-              .map(v => v.data.data.reviews)
+              .map(v => v.data.data.list)
               .flat()
               .map(data => <OneReview mutate={mutate} key={v4()} list={data} />)
           ) : (

--- a/src/types/review/review.ts
+++ b/src/types/review/review.ts
@@ -26,6 +26,11 @@ export interface ReviewResponseType {
   cursor: number;
 }
 
+export interface MyReviewResponseType {
+  list: ReviewDataType[];
+  cursor: number;
+}
+
 export interface ReviewStateType {
   prevImages: File[] | null;
   prevScore: number | null;


### PR DESCRIPTION
## 개요
- 백엔드쪽 api 응답의 data에 ReviewDataType[] list와 number cursor로 응답합니다.
- 해당 응답에 맞추고자, review.ts에 MyReviewResponseType 인터페이스를 추가했습니다.
- 지금 마이페이지 쪽에 에러가 뜨는 것도 아마 list이름이 아닌 posts 이렇게 설정돼있어서 에러가 뜨는 것으로 예상합니다.!

Resolves: #90

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
