### PR TITLE
Fix: #92 리뷰 작성이 중지되는 현상 수정

### DIFF
--- a/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
+++ b/src/app/_components/review/review-modal/ReviewRegisterModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { SetStateAction, useEffect, useMemo, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { Button } from '@/app/_components/ui/button';
@@ -17,23 +17,34 @@ import { getFormData } from '@/utils/getFormData';
 import reviewApi from '@/apis/review/apis/review';
 import { cn } from '@/lib/utils';
 import { ReviewRegisterProps } from '@/types/review/ReviewProps';
+import type {
+  ReviewRegisterType,
+  SubmitReviewType,
+} from '@/types/review/review';
 
 function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
-  const { closeMode, reviewState, state, reviewId } = useReviewStore(
-    state => state,
-  );
+  const { closeMode, reviewState, state, reviewId } = useReviewStore();
+  const initialValue = {
+    newContent: '',
+    newImages: [],
+    newScore: 5,
+    fixId: -1,
+  };
+  const [registerValue, setRegisterValue] =
+    useState<ReviewRegisterType>(initialValue);
 
-  let newContent: string = '';
-  let newImages: File[] = [];
-  let newScore: number = 5;
-  let fixId: number = -1;
+  const { newImages, newContent, newScore, fixId } = registerValue;
 
   if (state === 'fix') {
     const { prevContent, prevImages, prevScore, prevId } = reviewState;
-    newContent = prevContent as string;
-    newImages = prevImages as File[];
-    newScore = prevScore as number;
-    fixId = prevId as number;
+    const prevState = {
+      newContent: prevContent || '',
+      newImages: prevImages || [],
+      newScore: prevScore || 5,
+      fixId: prevId || -1,
+    };
+
+    setRegisterValue(prevState);
   }
 
   const isOpen = state === 'create' || state === 'fix';
@@ -44,36 +55,41 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
     { 'opacity-1 z-[1000]': isOpen },
   );
 
-  const [ratingValue, setRatingValue] = useState<number>(newScore);
-  const [images, setImages] = useState<File[]>(newImages);
-
   const form = useForm<ReviewSchemaType>({
     resolver: zodResolver(ReviewSchema),
   });
 
+  useEffect(() => {
+    if (state === 'review') {
+      setRegisterValue(initialValue);
+    }
+  }, [state]);
+
   const onSubmit = async (d: ReviewSchemaType) => {
     if (reviewId === null) return;
-
-    let data: { score: number; content: string; gym_id?: number } = {
-      score: ratingValue,
-      content: d.content ? d.content : '',
+    let data: SubmitReviewType = {
+      score: newScore,
+      content: d.content || '',
     };
 
     switch (state) {
       case 'fix': {
         const formData = getFormData({
           jsonData: JSON.stringify(data),
-          images,
+          images: newImages,
         });
         await reviewApi.patchReview(fixId, formData);
         mutate();
         break;
       }
       case 'create': {
-        data = { ...data, gym_id: reviewId };
+        data = {
+          ...data,
+          gym_id: reviewId,
+        };
         const formData = getFormData({
           jsonData: JSON.stringify(data),
-          images,
+          images: newImages,
         });
         await reviewApi.postReview(formData);
         mutate();
@@ -85,22 +101,50 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
     closeMode();
   };
 
-  let header = null;
-  let submit = null;
-  if (state === 'create') {
-    header = '리뷰 작성';
-    submit = '작성 완료';
-  } else if (state === 'fix') {
-    header = '리뷰 수정';
-    submit = '수정 완료';
-  }
+  // @ts-ignore
+  const setImages: React.Dispatch<SetStateAction<File[]>> = (
+    newImages: File[],
+  ) => {
+    setRegisterValue(prev => ({
+      ...prev,
+      newImages,
+    }));
+  };
+
+  const RegisterContent = useMemo(() => {
+    switch (state) {
+      case 'create': {
+        const header = '리뷰 작성';
+        const submit = '작성 완료';
+        return {
+          header,
+          submit,
+        };
+      }
+      case 'fix': {
+        const header = '리뷰 작성';
+        const submit = '작성 완료';
+        return {
+          header,
+          submit,
+        };
+      }
+      default: {
+        return {
+          header: null,
+          submit: null,
+        };
+      }
+    }
+  }, [state]);
+
   return (
     <div className={ModalClassName}>
       <div className=" h-[3.5rem] shadow flex items-center justify-center">
         <button type="button" className="absolute right-3" onClick={closeMode}>
           <X />
         </button>
-        {header}
+        {RegisterContent.header}
       </div>
       <div
         className={`mx-4 pt-4 text-[20px] border-b border-primary ${aBeeZee.className}`}
@@ -120,12 +164,18 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
             <Rating
               name="rating"
               size="large"
-              defaultValue={ratingValue}
+              defaultValue={registerValue.newScore}
               onChange={(_, newValue) => {
                 if (typeof newValue === 'number') {
-                  setRatingValue(newValue);
+                  setRegisterValue(prev => ({
+                    ...prev,
+                    newScore: newValue,
+                  }));
                 } else {
-                  setRatingValue(1);
+                  setRegisterValue(prev => ({
+                    ...prev,
+                    newScore: 1,
+                  }));
                 }
               }}
             />
@@ -151,9 +201,9 @@ function ReviewRegisterModal({ gym_name, mutate }: ReviewRegisterProps) {
           </div>
 
           <div className="flex flex-col items-end w-full gap-2 pb-4 z-50 bg-white">
-            <PhotoBooth images={images} setImages={setImages} />
+            <PhotoBooth images={newImages} setImages={setImages} />
             <Button type="submit" color="white" className="w-full">
-              {submit}
+              {RegisterContent.submit}
             </Button>
           </div>
         </form>

--- a/src/app/service/map/_components/search/SearchBar.tsx
+++ b/src/app/service/map/_components/search/SearchBar.tsx
@@ -50,7 +50,7 @@ function SearchBar({ isSearching, onSearchingFocus }: SearchKeyWordProps) {
             name="searchKeyword"
             id="searchKeyword"
             ref={searchRef}
-            placeholder="오늘은 어디를 가볼까?"
+            placeholder="암장 이름으로 검색하세요."
             onFocus={handleSearchFocus}
             className="w-full outline-0"
           />

--- a/src/app/service/map/_components/search/SearchBar.tsx
+++ b/src/app/service/map/_components/search/SearchBar.tsx
@@ -43,7 +43,6 @@ function SearchBar({ isSearching, onSearchingFocus }: SearchKeyWordProps) {
   return (
     <div className={containerClassName}>
       <form onSubmit={handleSearchSubmit} className={formClassName}>
-        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
         <label htmlFor="searchKeyword">
           <input
             defaultValue={keyword}
@@ -55,7 +54,6 @@ function SearchBar({ isSearching, onSearchingFocus }: SearchKeyWordProps) {
             className="w-full outline-0"
           />
         </label>
-        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
         <button
           type="submit"
           className="absolute right-2 top-1/2 translate-y-[-50%]"

--- a/src/app/service/map/page.tsx
+++ b/src/app/service/map/page.tsx
@@ -17,7 +17,7 @@ import ReviewModalContainer from '../../_components/review/review-modal/ReviewMo
 
 function Page() {
   const router = useRouter();
-  const closeModal = useReviewStore(state => state.reset);
+  const closeModal = useReviewStore(state => state.closeMode);
   const keyword = useSearchParams().get('keyword') ?? '';
   const selectId = useSearchParams().get('selectId') ?? '';
 
@@ -79,7 +79,7 @@ function Page() {
       handleCarouselClosed();
       closeModal();
     };
-  }, [data]);
+  }, []);
 
   const isEmptyData = !data || isLoading;
 

--- a/src/app/service/map/page.tsx
+++ b/src/app/service/map/page.tsx
@@ -17,7 +17,7 @@ import ReviewModalContainer from '../../_components/review/review-modal/ReviewMo
 
 function Page() {
   const router = useRouter();
-  const closeModal = useReviewStore(state => state.closeMode);
+  const { reset } = useReviewStore(state => state);
   const keyword = useSearchParams().get('keyword') ?? '';
   const selectId = useSearchParams().get('selectId') ?? '';
 
@@ -77,7 +77,7 @@ function Page() {
     return () => {
       handleImageClosed();
       handleCarouselClosed();
-      closeModal();
+      reset();
     };
   }, []);
 

--- a/src/types/review/review.ts
+++ b/src/types/review/review.ts
@@ -40,7 +40,6 @@ export interface ReviewStateType {
 
 export interface ReviewRegisterType {
   newContent: string;
-  newImages: File[];
   newScore: number;
   fixId: number;
 }

--- a/src/types/review/review.ts
+++ b/src/types/review/review.ts
@@ -32,3 +32,16 @@ export interface ReviewStateType {
   prevContent: string | null;
   prevId: number | null;
 }
+
+export interface ReviewRegisterType {
+  newContent: string;
+  newImages: File[];
+  newScore: number;
+  fixId: number;
+}
+
+export interface SubmitReviewType {
+  score: number;
+  content: string;
+  gym_id?: number;
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #92 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링

### 요청사항
>1. 지도 검색의 hint placehoder 변경

해당 부분 변경 하였습니다.

>2. 리뷰 수정/쓰기를 하다가 나올 경우 다시 들어갈 경우 이전에 작성중이던 글 안나오게 하기

해당 부분은 `Content` 부분이 공용 컴포넌트로 사용하고 있어 수정을 하지 않은 상태입니다. 하지만 저희 리뷰의 성격상 하나의 암장당 하나의 리뷰만 작성이 가능한 점 그리고 다른 암장 리뷰를 작성할 때는 초기화가 되어있다는 점을 생각해 보았을 때 이전에 작성중이던 `content` 내용이 보이는 것이 더 좋을 것이라고 생각합니다.

>3.  이미지를 넣고 추가할시 튕기는 현상/커뮤니티의 코드를 가져다가 썼기 때문에 폼은 동일하지만 알 수 없는 현상

해당 부분은 무분별한 `state` 사용으로 인한 문제가 있었습니다.

```tsx
useEffect(() => {
    if (selectId !== '') {
      const selectItem = data?.data.data.filter(
        v => v.id === Number(selectId),
      )[0];

      if (selectItem) {
        handleMovePosition(selectItem);
      }
    }

    return () => {
      handleImageClosed();
      handleCarouselClosed();
      closeModal();
    };
  }, [data]);
```

첫번째로 잘못된 state 사용이 있습니다.

swr을 사용하니 화면이 `focus` 가 될 때마다 data를 다시 fetch 해오고 있었습니다. 때문에 `useEffect`가 다시 실행이 됩니다. 이를 통해서 변경이 될 때 마다 `return` 내의 `componentDidMount()`에 해당하는 초기화 메소드가 실행이 되기 때문에 모달이 지속적으로 닫혔습니다.


### 변경 사항
1. React의 특징에 맞게 `state`를 사용하여 변수를 관리하였습니다.

또한 `initalState`의 값이 객체로 크기가 크고 수정 및 추가도 같이 관리하는 컴포넌트 이기 때문에 예외 상황을 고려하여 함수의 리턴문으로 선언하였습니다. 이를 통해 해당 컴포넌트가 렌더링이 됐을 경우 state 값을 적용하게 설정하였습니다.

2. useMemo를 사용하여 렌더링 시간을 단축하였습니다.

### 고려 사항
현재 `PhotoBooth` 컴포넌트는 다음과 같은 형식으로 만들어져 있습니다.

```ts
export interface PhotoBoothProps {
  images: File[];
  setImages: Dispatch<SetStateAction<File[]>>;
}
```

생각을 해본다면 `form` 형식을 사용할 경우 이미지만 보낼 경우는 적고 다른 `formData`의 값들과 보내는 경우가 많습니다. 

때문에 저 같은 경우 원래 다음과 같이 보낼 타입들을 한번에 명시해서 담아두고 `state`를 사용하여 보내기도 합니다.
```tsx
export interface ReviewRegisterType {
  newContent: string;
  newImages: File[];
  newScore: number;
  fixId: number;
}
```

하지만 위와같이 `state`를 만든다고 하면 `PhotoBoothProps` 에는 `setImages()`함수를 넘겨줄 수 없습니다. 왜냐하면 `Dispatch<SetStateAction<ReviewRegisterType>>` 타입은 넘겨줄 수 가 없기 때문입니다.

🧐 그럼 생각을 해볼수 있습니다. 

어떻게 하면 `SetStateAction<T>`로 넘겨줄 수 있을까? 다음과 같습니다.

```tsx
// @ts-ignore
const setImages: React.Dispatch<SetStateAction<File[]>> = (
    newImages: File[],
  ) => {
    setRegisterValue(prev => ({
      ...prev,
      newImages,
    }));
  };
```

하지만 이 타입은 저희가 가상으로 만들어 줬고 type 오류가 납니다. 때문에 ts-ignore를 선언을 해주어야 합니다.  

원래 타입은 다음과 같습니다. `setImages : (newImages: File[]) => void`

만약 위와같이 만들기 싫다면 state를 하나 더 선언하는 방법이 있긴합니다...만 많은 state들은 렌더링 요청 추적을 어렵게 하여 디버깅이나 개발에 골칫거리가 될 수 있습니다. 때문에 비슷한 state들은 묶는 것이 좋습니다. 렌더링 추적이 용이하니까요.

만약 제가 해당 컴포넌트를 만들었다면 다음과 같이 만들었을 것 같습니다.

```tsx
export interface PhotoBoothProps {
  images: File[];
  setImages: Dispatch<SetStateAction<File[]>> | (newImages : File[]) => void;
}
```

이렇게 만들어 둔다면 객체로 만들어져 있는 state들 중에서도 하나만 가져와서 값을 변경 할 수 있을 것 같습니다..!

### 에러 상황

현재 리뷰를 올바르게 디버깅을 하지 못하는 상태입니다. 수정 상태 둘 다 403(권한 없음)이 뜨고있습니다. 해당 부분은 back-end 분들이 확인을 해주셔야 합니다.
![image](https://github.com/Kernel360/f1-Orury-Client/assets/115636461/0ff44bea-1329-455b-a515-6ff2f0be693e)


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
