### PR TITLE
Fix: MyPosts&MyComments api 호출 시, AxiosResponse<> 추가

### DIFF
--- a/src/app/service/user/_components/UserCommentsModal.tsx
+++ b/src/app/service/user/_components/UserCommentsModal.tsx
@@ -11,7 +11,7 @@ function UserCommentModal({ ...props }: UserModalProps) {
   const { data, size, setSize, isValidating } =
     useUserPostListInfinite('comment');
 
-  const posts = data?.flatMap(page => page.data.list);
+  const posts = data ? data.flat().flatMap(page => page.data.data.list) : [];
   const bottomRef = useIntersect(() => {
     if (!isValidating) setSize(size + 1);
   });

--- a/src/app/service/user/_components/UserPostsModal.tsx
+++ b/src/app/service/user/_components/UserPostsModal.tsx
@@ -9,7 +9,7 @@ function UserPostsModal({ ...props }: UserModalProps) {
   const { user_profile_image, user_nickname, user_id } = props;
   const { data, size, setSize, isValidating } = useUserPostListInfinite('post');
 
-  const posts = data?.flatMap(page => page.data.list);
+  const posts = data ? data.flat().flatMap(page => page.data.data.list) : [];
   const bottomRef = useIntersect(() => {
     if (!isValidating) setSize(size + 1);
   });

--- a/src/hooks/user/useUserPostListInfinite.ts
+++ b/src/hooks/user/useUserPostListInfinite.ts
@@ -1,10 +1,10 @@
-import {TResponse} from '@/types/common/response';
-import {axiosInstance} from '@/lib/axios/axios-instance';
-import {getUserPostListKey} from '@/utils/getKeys';
-import type {MyPostListData} from '@/types/community/post';
+import { TResponse } from '@/types/common/response';
+import { axiosInstance } from '@/lib/axios/axios-instance';
+import { getUserPostListKey } from '@/utils/getKeys';
+import type { MyPostListData } from '@/types/community/post';
 
 import useSWRInfinite from 'swr/infinite';
-import {AxiosResponse} from "axios";
+import { AxiosResponse } from 'axios';
 
 function useUserPostListInfinite(state: 'post' | 'comment') {
   return useSWRInfinite<AxiosResponse<TResponse<MyPostListData>>[]>(

--- a/src/hooks/user/useUserPostListInfinite.ts
+++ b/src/hooks/user/useUserPostListInfinite.ts
@@ -1,12 +1,13 @@
-import { TResponse } from '@/types/common/response';
-import { axiosInstance } from '@/lib/axios/axios-instance';
-import { getUserPostListKey } from '@/utils/getKeys';
-import type { MyPostListData } from '@/types/community/post';
+import {TResponse} from '@/types/common/response';
+import {axiosInstance} from '@/lib/axios/axios-instance';
+import {getUserPostListKey} from '@/utils/getKeys';
+import type {MyPostListData} from '@/types/community/post';
 
 import useSWRInfinite from 'swr/infinite';
+import {AxiosResponse} from "axios";
 
 function useUserPostListInfinite(state: 'post' | 'comment') {
-  return useSWRInfinite<TResponse<MyPostListData>>(
+  return useSWRInfinite<AxiosResponse<TResponse<MyPostListData>>[]>(
     (pageIndex, previousPageData) =>
       getUserPostListKey(pageIndex, state, previousPageData),
     axiosInstance.get,


### PR DESCRIPTION
## 개요
현재 내 게시글 조회, 내 댓글 조회가 되지 않아
기존에 작성된 내 리뷰 조회 코드를 참고하여, 정상적으로 작동될 수 있도록 코드 일부 수정했습니다.

AxiosResponse를 써야 응답 객체의 타입을 명확히 할 수 있다고 합니다.

로컬에 백엔드/프론트엔드 서버 모두 띄우고, 정상 작동하는 것도 확인했습니다. 

Resolves: 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
