### PR TITLE
Fix: #90 마이페이지 리뷰 조회시 나오지 않는 현상

### DIFF
--- a/src/app/_components/review/review-modal/MyReviewModal.tsx
+++ b/src/app/_components/review/review-modal/MyReviewModal.tsx
@@ -9,13 +9,14 @@ import { useEffect } from 'react';
 import NotSearched from '@/app/service/community/_components/NotSearched';
 import ReviewModalSkeleton from './ReviwModalSkeleton';
 import OneReview from './OneReview';
+import ReviewRegisterModal from './ReviewRegisterModal';
 
 /**
  * @description 지도 위에 띄위기 위해서 Modal로 구현을 합니다.
  * @param position 어느 방향에서 모달이 열릴지 결정합니다.
  */
 function MyReviewModal({ openPosition }: ReviewProps) {
-  const { isOpen, reset, state } = useReviewStore(state => state);
+  const { isOpen, reset } = useReviewStore(state => state);
 
   const { data, mutate, size, setSize, isLoading, isValidating } =
     useReviewApi.useGetMyReviews();
@@ -60,14 +61,15 @@ function MyReviewModal({ openPosition }: ReviewProps) {
   }
 
   return (
-    <div className={ModalClassName}>
-      <div className="w-full max-w-[768px] z-[101] px-1 h-[3.5rem] fixed shadow flex items-center justify-center">
-        <button type="button" className={PositionClassName} onClick={reset}>
-          {openPosition === 'center' ? <ChevronDown /> : <ChevronLeft />}
-        </button>
-        내가 작성한 리뷰
-      </div>
-      {state === 'mypage' && (
+    <>
+      <ReviewRegisterModal mutate={mutate} />
+      <div className={ModalClassName}>
+        <div className="w-full max-w-[768px] z-[101] px-1 h-[3.5rem] fixed shadow flex items-center justify-center">
+          <button type="button" className={PositionClassName} onClick={reset}>
+            {openPosition === 'center' ? <ChevronDown /> : <ChevronLeft />}
+          </button>
+          내가 작성한 리뷰
+        </div>
         <div className="relative mt-[3.5rem]">
           {reviews[0].data.data.cursor !== -2 ? (
             reviews
@@ -79,8 +81,8 @@ function MyReviewModal({ openPosition }: ReviewProps) {
           )}
           <div ref={bottomRef} />
         </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

Resolves: #90

### 마이페이지 리뷰에 대한 기능을 추가하였습니다.
<img src="https://github.com/Kernel360/f1-Orury-Client/assets/115636461/5c31bd23-d2f1-4d2c-9338-48394f9b081e" width="200px"/>

### 버그가 있습니다.

1. 이미지를 등록할 경우 프로필 이미지가 수정이 됩니다.
<img src="https://github.com/Kernel360/f1-Orury-Client/assets/115636461/e1a0fa44-230e-48af-902d-42f353369cb4" width="200px"/>

2. 이미지를 수정할 경우 원래 있던 이미지를 요청해서 가져오는데 해당 부분에서 버그가 있습니다.

![image](https://github.com/Kernel360/f1-Orury-Client/assets/115636461/5fceb3e6-c8e4-4954-b89f-a0cb7be6107c)

현재 로직은 다음과 같이 작성되어 있습니다.

```tsx
 const onFixHandling = async () => {
    const convertedImages = await Promise.all(
      images.map(v => convertURLtoFile(v)),
    );
    setFixMode({
      prevContent: content,
      prevImages: convertedImages,
      prevScore: score,
      prevId: id,
    });
  };
```
수정을 시도할 경우 전역 변수로 이전 값들을 세팅을 합니다. 또한 `convertURLtoFile()` 메소드를 통해 URL을 통해 불러온 이미지를 blob데이터로 변환을 시도합니다.

```tsx
const accessToken = decrypt(getCookie({ name: 'access_token' }));

export const convertURLtoFile = async (url: string) => {
  const response = await axios.get(url, {
    headers: { Authorization: `Bearer ${accessToken}` },
    responseType: 'blob',
  });
  const data = new Blob([response.data]);
  const ext = url.split('.').pop();
  const filename = url.split('/').pop();
  const metadata = { type: `image/${ext}` };
  const file = new File([data], filename!, metadata);
  return file;
};
```

해당 blob 데이터는 `file` 형태로 변환되어 나오게 됩니다. 하지만 CORS 에러가 발생하고 있습니다.

백엔드에서 해당 S3 주소로 직접적인 접근을 막아둔것이 아닐까라는 생각이 있습니다.
## PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
