### PR TITLE
Fix: #84 커뮤니티 게시글 이미지 로직 변경

### DIFF
--- a/src/app/_components/review/review-modal/MyReviewModal.tsx
+++ b/src/app/_components/review/review-modal/MyReviewModal.tsx
@@ -64,7 +64,7 @@ function MyReviewModal({ openPosition }: ReviewProps) {
     <>
       <ReviewRegisterModal mutate={mutate} />
       <div className={ModalClassName}>
-        <div className="w-full max-w-[768px] z-[101] px-1 h-[3.5rem] fixed shadow flex items-center justify-center">
+        <div className="w-full bg-white max-w-[768px] z-[101] px-1 h-[3.5rem] fixed shadow flex items-center justify-center">
           <button type="button" className={PositionClassName} onClick={reset}>
             {openPosition === 'center' ? <ChevronDown /> : <ChevronLeft />}
           </button>

--- a/src/app/_components/review/review-modal/ReviewModalContainer.tsx
+++ b/src/app/_components/review/review-modal/ReviewModalContainer.tsx
@@ -8,11 +8,13 @@ function ReviewModalContainer({
   isMyPage,
   openPosition,
 }: ReviewModalContainerProps) {
-  const { reviewId } = useReviewStore(state => state);
+  const { reviewId, isOpen } = useReviewStore(state => state);
 
   if (!isMyPage && reviewId === null) {
     return <ReviewModalSkeleton openPosition={openPosition} />;
   }
+
+  if (!isOpen) return null;
 
   if (isMyPage) {
     return <MyReviewModal openPosition={openPosition} />;

--- a/src/app/service/_components/Notice.tsx
+++ b/src/app/service/_components/Notice.tsx
@@ -4,12 +4,11 @@ import Autoplay from 'embla-carousel-autoplay';
 import * as C from '@/app/_components/ui/carousel';
 import useEmblaCarousel from 'embla-carousel-react';
 
-// import { v4 } from 'uuid';
+import { v4 } from 'uuid';
 import { COLOR } from '@/styles/color';
 import { Megaphone, Tally1 } from 'lucide-react';
 import { EmblaOptionsType } from 'embla-carousel';
 import { useEffect } from 'react';
-import Link from 'next/link';
 
 function Notice() {
   const OPTIONS: EmblaOptionsType = { align: 'start', loop: true, axis: 'y' };
@@ -36,16 +35,11 @@ function Notice() {
 
       <C.Carousel opts={OPTIONS} orientation="vertical">
         <C.CarouselContent ref={emblaRef}>
-          {/* {NOTICE.map(value => (
+          {NOTICE.map(value => (
             <C.CarouselItem key={v4()}>
               <span className="ellipsis">{value}</span>
             </C.CarouselItem>
-          ))} */}
-          <C.CarouselItem>
-            <Link href="https://forms.gle/eLejpGHoE1PTyn79A" target="_blank">
-              Orury 고객의 소리함 바로가기
-            </Link>
-          </C.CarouselItem>
+          ))}
         </C.CarouselContent>
       </C.Carousel>
     </div>

--- a/src/app/service/community/[id]/page.tsx
+++ b/src/app/service/community/[id]/page.tsx
@@ -19,7 +19,7 @@ function Page({ params }: { params: { id: string } }) {
   const [postDetail, setPostDetail] = useState<PostDetailProps>();
   const [isEditButtonClicked, setIsEditButtonClicked] = useState(false);
 
-  const editHandler = () => {
+  const handleEditMode = () => {
     setIsEditButtonClicked(isEditButtonClicked => !isEditButtonClicked);
   };
 
@@ -41,8 +41,8 @@ function Page({ params }: { params: { id: string } }) {
         isEllipsis={postDetail?.is_mine && !isEditButtonClicked}
         isBack={!isEditButtonClicked}
         isExit={isEditButtonClicked}
-        exitHandler={editHandler}
-        editHandler={editHandler}
+        exitHandler={handleEditMode}
+        editHandler={handleEditMode}
       />
       <ImageSliderModal />
       <div className="flex flex-col  relative h-full-size-omit-nav">
@@ -55,7 +55,7 @@ function Page({ params }: { params: { id: string } }) {
             title={postDetail?.title}
             content={postDetail?.content}
             images={postDetail?.images}
-            editHandler={editHandler}
+            editHandler={handleEditMode}
             isPostDetail
           />
         )}

--- a/src/app/service/community/_components/PhotoBooth.tsx
+++ b/src/app/service/community/_components/PhotoBooth.tsx
@@ -40,7 +40,6 @@ function PhotoBooth({ ...props }: PhotoBoothProps) {
   };
 
   useMemo(() => {
-    console.log(images);
     if (images.length > 5) {
       setImages(prevImages => prevImages.splice(0, 5));
       toast({

--- a/src/app/service/community/_components/PhotoBooth.tsx
+++ b/src/app/service/community/_components/PhotoBooth.tsx
@@ -40,6 +40,7 @@ function PhotoBooth({ ...props }: PhotoBoothProps) {
   };
 
   useMemo(() => {
+    console.log(images);
     if (images.length > 5) {
       setImages(prevImages => prevImages.splice(0, 5));
       toast({

--- a/src/app/service/community/api/editPost.ts
+++ b/src/app/service/community/api/editPost.ts
@@ -1,28 +1,19 @@
-import CustomError from '@/error/CustomError';
 import { axiosInstance } from '@/lib/axios/axios-instance';
 import { END_POINT } from '@/constants/api/end-point';
 import { TResponse } from '@/types/common/response';
 
 const editPost = async (formData: FormData) => {
-  try {
-    const { data: response } = await axiosInstance.patch<TResponse<null>>(
-      END_POINT.postController.main,
-      formData,
-      {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+  const { data: response } = await axiosInstance.patch<TResponse<null>>(
+    END_POINT.postController.main,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
       },
-    );
+    },
+  );
 
-    return response.message;
-  } catch (error: unknown) {
-    if (error instanceof CustomError) {
-      throw new Error(error.message);
-    }
-
-    throw new Error(error as any);
-  }
+  return response.message;
 };
 
 export default editPost;

--- a/src/app/service/user/_components/Profile.tsx
+++ b/src/app/service/user/_components/Profile.tsx
@@ -79,7 +79,6 @@ function Profile({ ...props }: ProfileProps) {
           <Image
             src={profileImage}
             alt="프로필 이미지"
-            quality={100}
             fill
             priority
             className="rounded-full"
@@ -87,7 +86,7 @@ function Profile({ ...props }: ProfileProps) {
         </div>
 
         <label
-          htmlFor="photo"
+          htmlFor="userProfileImage"
           className="flex justify-center items-center w-8 h-8 absolute right-0 bottom-0 bg-purple-200 rounded-full cursor-pointer"
         >
           <D.DropdownMenu>
@@ -117,7 +116,7 @@ function Profile({ ...props }: ProfileProps) {
 
       <input
         type="file"
-        id="photo"
+        id="userProfileImage"
         accept="image/*"
         onChange={handleProfileImageChange}
         className="hidden"

--- a/src/app/service/user/page.tsx
+++ b/src/app/service/user/page.tsx
@@ -58,7 +58,7 @@ function Page() {
 
   return (
     <div className="relative">
-      {category && (
+      {category && category !== 'review' && (
         <Header
           title={getHeaderTitle(category)}
           isExit

--- a/src/store/community/postsStore.ts
+++ b/src/store/community/postsStore.ts
@@ -13,8 +13,10 @@ export const usePostsState = create<UsePostsStateProps>(set => ({
 export const useOnePostState = create<UseOnePostState>(set => ({
   title: '',
   content: '',
+  images: [],
   setTitle: value => set({ title: value }),
   setContent: value => set({ content: value }),
+  setImages: value => set(state => ({ ...state, images: value })),
 }));
 
 export const postCountState = create<PostCountState>(set => ({

--- a/src/types/common/form.ts
+++ b/src/types/common/form.ts
@@ -5,7 +5,7 @@ export type FormType = {
   category?: number;
   title?: string;
   content?: string;
-  images?: string[] | string;
+  images?: string[];
   isPost?: boolean;
   isPostDetail?: boolean;
   isReview?: boolean;

--- a/src/types/community/post.ts
+++ b/src/types/community/post.ts
@@ -59,8 +59,10 @@ export interface UsePostsStateProps {
 export interface UseOnePostState {
   title: string;
   content: string;
+  images: string[];
   setTitle: (value: string) => void;
   setContent: (value: string) => void;
+  setImages: (value: string[] | undefined) => void;
 }
 
 export interface PostCountState {


### PR DESCRIPTION
## 개요
커뮤니티 내 게시글 수정 시 이미지를 다루는 로직을 변경했습니다.

게시글 수정 시, 서버에서 받아왔던 S3 이미지 주소를 모두 `File` type으로 변환합니다.

```js
useEffect(() => {
    const convertImagesType = async () => {
      if (images) {
        const convertedImages = await Promise.all(
          images.map(image => convertURLtoFile(image)),
        );

        setNewImages(convertedImages);
      }
    };

    convertImagesType();
  }, []);
```

Resolves: #(Isuue Number)

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://www.notion.so/e3110b52de8442e18f60b23a85933dbb?pvs=4).
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
